### PR TITLE
Handle return value from permissionsAndroid.request()

### DIFF
--- a/src/handlePermissions.js
+++ b/src/handlePermissions.js
@@ -19,8 +19,7 @@ export const requestPermissions = async (hasVideoAndAudio, CameraManager, permis
           // On devices before SDK version 23, the permissions are automatically granted if they appear in the manifest,
           // so check and request should always be true.
           // https://github.com/facebook/react-native-website/blob/master/docs/permissionsandroid.md
-          const isAuthorized =
-            Platform.Version >= 23 ? granted === PermissionsAndroid.RESULTS.GRANTED : granted === true;
+          const isAuthorized = granted === PermissionsAndroid.RESULTS.GRANTED;
     
           return isAuthorized;
     }


### PR DESCRIPTION
According to [documentation](https://facebook.github.io/react-native/docs/permissionsandroid.html): 
`PermissionsAndroid.request()` returns a promise resolving to a string value('granted', 'denied' or 'never_ask_again' ), not a boolean value.
 So there is no need to check device's API level because if it's below 23, It's always `PermissionsAndroid.RESULTS.GRANTED`.